### PR TITLE
Return terraform.ResourceProvider interface

### DIFF
--- a/ironic/provider.go
+++ b/ironic/provider.go
@@ -3,10 +3,11 @@ package ironic
 import (
 	"github.com/gophercloud/gophercloud/openstack/baremetal/noauth"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 // Provider Ironic
-func Provider() *schema.Provider {
+func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"url": {


### PR DESCRIPTION
Despite the [Terraform docs](https://www.terraform.io/docs/extend/writing-custom-providers.html#the-provider-schema), ProviderFunc actually needs to return the `terraform.ResourceProvider` interface, otherwise kni-installer can't use it:

```
# github.com/openshift-metalkube/kni-installer/pkg/terraform/exec/plugins
pkg/terraform/exec/plugins/ironic.go:13:4: cannot use ironic.Provider (type func() *schema.Provider) as type "github.com/openshift-metalkube/kni-installer/pkg/terraform/exec/vendor/github.com/hashicorp/terraform/plugin".ProviderFunc in field value
```